### PR TITLE
rename environment varialbe SOCKET

### DIFF
--- a/mpvc
+++ b/mpvc
@@ -4,7 +4,7 @@
 # control mpv remotely using JSON ipc
 # https://mpv.io/manual/master/#json-ipc
 
-SOCKET=${SOCKET:-/tmp/mpvsocket}
+SOCKET=${MPVC_SOCKET:-/tmp/mpvsocket}
 MPVOPTIONS="--no-audio-display"
 
 usage() {


### PR DESCRIPTION
The external envrionemnt varialbe `SOCKET` is renamed to `MPVC_SOCKET`. It allow to configure `mpvc` system wide and avoiding any conflict with similar named environment variable.

In my case I use `$XDG_RUNTIME_DIR/mpv.socket` as my socket and want to use `mpvctl` from `sxhkd` so I was forced to specify the socket each time I wanted to add a new shortcut. Now I can set `~/.profile` and forget about the socket location.