### PR TITLE
FIx ipc-server command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ but by default will close the ipc-server when all files have finished playing.
 
 To keep the ipc-server open permanently, use:
 ```
-$ mpv --input-ipc-server /tmp/mpvsocket
+$ mpv --input-ipc-server=/tmp/mpvsocket
 ```
 
 You can also specify the default ipc server in your $XDG_CONFIG_HOME/mpv.conf


### PR DESCRIPTION
Hi! mpv with the arguments `--input-ipc-server /tmp/mpvsocket` complains on my machine, I believe it should be `mpv --input-ipc-server=/tmp/mpvsocket`, with the equals. Thanks!